### PR TITLE
Add technical team hashtags

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
           a section here.
         </p>
         <div class="row">
+	  <h2>Organisation wide hashtags</h2>
           <div class="large-3 medium-3 columns">
             <p><a href="{{ url_for('entry_show', name='success') }}">#success</a><br />Sharing the successes across the organization!</p>
         </div>
@@ -22,6 +23,12 @@
           <p><a href="{{ url_for('entry_show', name='nowlistening') }}">#NowListening</a><br />We love diverse &#9834; music and let's share it all! &#9835; </p>
         </div>
       </div>
+	<div class="row">
+	  <h2>Technical team hashtags</h2>
+	  <div class="large-3 medium-3 columns">
+            <p><a href="{{ url_for('entry_show', name='presales') }}">#presales</a><br />Presales request made to the technical team</p>
+	  </div>
+	</div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
The only hashtag recorded by the technical team at the moment is
presales, but more might come in the future and it's good to keep
this separated from the organisation wide hashtags.
